### PR TITLE
ci: allow Windows builds to fail and skip compile/test steps on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ jobs:
       matrix:
         os:   [ 'ubuntu', 'macos', 'windows' ]
         ruby: [ '3.2', '3.3', '3.4' ]
+    # TODO: Remove continue-on-error and Windows skip conditions once numo-narray releases a fix for Windows
+    continue-on-error: ${{ matrix.os == 'windows' }}
     steps:
     - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
@@ -16,4 +18,6 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
     - run: bundle exec rake compile
+      if: ${{ runner.os != 'Windows' }}
     - run: bundle exec rake test
+      if: ${{ runner.os != 'Windows' }}


### PR DESCRIPTION
## Summary
- Add `continue-on-error` for Windows matrix jobs to prevent CI failure when Windows builds fail
- Skip `compile` and `test` steps on Windows since the native extension doesn't support Windows yet
- Add TODO comment to track when this workaround can be removed

## Background
Windows builds are currently failing because the numo-narray gem has issues on Windows, and the fix has not been released yet.

This change allows the CI workflow to pass while keeping Windows jobs visible, so we can re-enable them once a new version of numo-narray is released.