### PR TITLE
Fix build error with rice 4.6.x by adding `ruby/thread.h`

### DIFF
--- a/ext/umappp/umappp.cpp
+++ b/ext/umappp/umappp.cpp
@@ -5,6 +5,7 @@
 
 #include <rice/rice.hpp>
 #include <rice/stl.hpp>
+#include <ruby/thread.h>
 #include <exception>
 #include <string>
 #include "numo.hpp"


### PR DESCRIPTION
## Summary

This PR fixes a compilation error that occurs when building umappp with rice 4.6.x.

## Problem

When using rice 4.6.1, the build fails with the following error:

```console
cd tmp/x86_64-linux/umappp/3.4.7
compiling ../../../../ext/umappp/umappp.cpp
../../../../ext/umappp/umappp.cpp: In function ‘Rice::Object umappp_run(Rice::Object, Rice::Hash, numo::SFloat, int, int)’:
../../../../ext/umappp/umappp.cpp:243:3: error: ‘rb_thread_call_without_gvl’ was not declared in this scope
  243 |   rb_thread_call_without_gvl(
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~
gmake: *** [Makefile:243: umappp.o] Error 1
```

( https://github.com/takahashim/ruby-umappp/actions/runs/19883967639/job/56987373401?pr=1 )

## Cause

- In rice 4.7.0+, `ruby/thread.h` is included automatically in `rice.hpp`
- In rice 4.6.x, this header is not included, so `rb_thread_call_without_gvl` is not declared

## Solution

Explicitly include `<ruby/thread.h>` in `umappp.cpp`. This should be safe for both rice versions because the header has include guards.

## Testing

This fix allows umappp to build successfully with both rice 4.6.x and 4.7.x. 

- https://github.com/takahashim/ruby-umappp/actions/runs/19883882732/job/56987134956